### PR TITLE
Process latitude and longitude columns specially in user datasets

### DIFF
--- a/Load/bin/exportInvestigation.pl
+++ b/Load/bin/exportInvestigation.pl
@@ -75,6 +75,7 @@ if($ontologyOwlFile){
 }
 
 if($autoMode){
+    warn "I am in autoMode\n";
   my $dir = "";
   if($targetDir){
     $dir = $targetDir;
@@ -98,6 +99,7 @@ if($autoMode){
    #  push(@mergedFiles,$mergedFile);
    #  push(@protocols,$protocol) if $protocol;
    #}
+    warn "I am in autoMode studyParams\n";
     foreach my $k ( 0 .. $#studyParams){
       my ($mergedFile,$entity,$primaryKey,$protocol,$parent,$parentKey) = preprocessStudy($studyParams[$k],$dir);
       $inv->addStudy($mergedFile,$entity,$primaryKey,$protocol,$parent,$parentKey);
@@ -107,7 +109,10 @@ if($autoMode){
   }
   else {
     ## use raw files
+    warn "I am in autoMode use raw files\n";
     foreach my $file (@mdFiles){
+      warn "I am in autoMode raw file '$file'\n";
+
       my $cleanFilename = basename($file);
       $cleanFilename =~ s/[^A-Za-z0-9_.]/_/g;
       my $dest = join("/", $dir, $cleanFilename);

--- a/Load/bin/exportInvestigation.pl
+++ b/Load/bin/exportInvestigation.pl
@@ -75,7 +75,6 @@ if($ontologyOwlFile){
 }
 
 if($autoMode){
-    warn "I am in autoMode\n";
   my $dir = "";
   if($targetDir){
     $dir = $targetDir;
@@ -99,7 +98,6 @@ if($autoMode){
    #  push(@mergedFiles,$mergedFile);
    #  push(@protocols,$protocol) if $protocol;
    #}
-    warn "I am in autoMode studyParams\n";
     foreach my $k ( 0 .. $#studyParams){
       my ($mergedFile,$entity,$primaryKey,$protocol,$parent,$parentKey) = preprocessStudy($studyParams[$k],$dir);
       $inv->addStudy($mergedFile,$entity,$primaryKey,$protocol,$parent,$parentKey);
@@ -109,10 +107,7 @@ if($autoMode){
   }
   else {
     ## use raw files
-    warn "I am in autoMode use raw files\n";
     foreach my $file (@mdFiles){
-      warn "I am in autoMode raw file '$file'\n";
-
       my $cleanFilename = basename($file);
       $cleanFilename =~ s/[^A-Za-z0-9_.]/_/g;
       my $dest = join("/", $dir, $cleanFilename);


### PR DESCRIPTION
In this PR, we assign the appropriate IRIs OBI_0001620 and OBI_0001621 to columns named latitude and longitude (case insensitive).

It has been tested via an isolated container run and the ontology files were created correctly.

Do the geohash_X variables need to be included in the ontology file? (they get added to the EDA tables automatically in InsertEntityGraph)

As reported [here](https://veupathdb.atlassian.net/wiki/spaces/~61aa65f9fe9f300068d0b8bd/pages/293404764/Latitude+longitude+handling+in+User+Datasets#Make-the-changes) there were problems running the loading code - something wrong with my user login ID. Testing in proper context still needs to be worked out with @dmgaldi @jaycolin and @jbrestel - so added you all as reviewers just so it gets on your radar.  Will organise via Slack too!